### PR TITLE
fix lint errors

### DIFF
--- a/common/openapi.go
+++ b/common/openapi.go
@@ -127,9 +127,9 @@ func CopyOpenAPI(repo, service, outfile string) error {
 		return err
 	}
 
-	filepath := path.Join(goModCache, repo+"@"+version.String(), "openapi", service, "openapi.json")
+	fp := path.Join(goModCache, repo+"@"+version.String(), "openapi", service, "openapi.json")
 
-	return copyFile(filepath, outfile, true)
+	return copyFile(fp, outfile, true)
 }
 
 func copyFile(src, dst string, overwrite bool) error {

--- a/deps/lib.go
+++ b/deps/lib.go
@@ -40,80 +40,25 @@ func DefLibDep(name, url, version, sha string, options ...Option) {
 }
 
 func downloadZippedLib(name, url, version, sha, prefix string, patterns []string) {
-	filePath := tmpFile(name + ".zip")
-	defer os.RemoveAll(filepath.Dir(filePath))
-	versionedURL := versionTemplate(url, version)
-
-	ui.Note().WithStringValue("zip", name).WithStringValue("url", versionedURL).Msg("Downloading ...")
-	err := downloadFile(filePath, versionedURL)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to download file"))
-	}
-
-	ui.Note().WithStringValue("zip", name).Msg("Checking signature ...")
-	verifyFile(filePath, sha)
-
-	libPath := LibDir()
-	err = os.MkdirAll(libPath, 0700)
-	if err != nil {
-		panic(errors.Wrapf(err, "failed to create directory '%s'", libPath))
-	}
-
-	unzipDir := mkTmpDir()
-	defer os.RemoveAll(unzipDir)
-	_, err = fsutil.Unzip(filePath, unzipDir)
-	if err != nil {
-		panic(errors.Wrapf(err, "failed to unzip '%s'", filePath))
-	}
-
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(unzipDir, pattern))
-		if err != nil {
-			panic(errors.Wrapf(err, "failed to glob using pattern '%s'", pattern))
-		}
-
-		for _, m := range matches {
-			ui.Note().WithStringValue("  match", m).Msg("> lib file")
-			relPath, err := filepath.Rel(unzipDir, m)
-			if err != nil {
-				panic(errors.Wrapf(err, "failed to get relative path for '%s'", m))
-			}
-
-			if prefix != "" {
-				prefix = versionTemplate(prefix, version)
-				relPath, err = filepath.Rel(prefix, relPath)
-				if err != nil {
-					panic(errors.Wrapf(err, "failed to calculate relative path using prefix '%s' for path '%s'", prefix, relPath))
-				}
-			}
-
-			dst := filepath.Join(libPath, relPath)
-			dstDir := filepath.Dir(dst)
-			err = os.MkdirAll(dstDir, 0700)
-			if err != nil {
-				panic(errors.Wrapf(err, "failed to create dir '%s'", dstDir))
-			}
-
-			err = os.Rename(m, dst)
-			if err != nil {
-				panic(errors.Wrapf(err, "failed to move '%s' to '%s'", m, dst))
-			}
-		}
-	}
+	downloadLib(name, url, version, sha, "zip", prefix, patterns)
 }
 
 func downloadTgzLib(name, url, version, sha, prefix string, patterns []string) {
-	filePath := tmpFile(name + ".zip")
+	downloadLib(name, url, version, sha, "tgz", prefix, patterns)
+}
+
+func downloadLib(name, url, version, sha, extension, prefix string, patterns []string) {
+	filePath := tmpFile(name + "." + extension)
 	defer os.RemoveAll(filepath.Dir(filePath))
 	versionedURL := versionTemplate(url, version)
 
-	ui.Note().WithStringValue("tgz", name).WithStringValue("url", versionedURL).Msg("Downloading ...")
+	ui.Note().WithStringValue(extension, name).WithStringValue("url", versionedURL).Msg("Downloading ...")
 	err := downloadFile(filePath, versionedURL)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to download file"))
 	}
 
-	ui.Note().WithStringValue("tgz", name).Msg("Checking signature ...")
+	ui.Note().WithStringValue(extension, name).Msg("Checking signature ...")
 	verifyFile(filePath, sha)
 
 	libPath := LibDir()
@@ -124,7 +69,9 @@ func downloadTgzLib(name, url, version, sha, prefix string, patterns []string) {
 
 	unpackDir := mkTmpDir()
 	defer os.RemoveAll(unpackDir)
-	err = fsutil.ExtractTarGz(filePath, unpackDir)
+
+	err = fsutil.Extract(extension, filePath, unpackDir)
+
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to unpack '%s'", filePath))
 	}

--- a/fsutil/extract.go
+++ b/fsutil/extract.go
@@ -1,0 +1,15 @@
+package fsutil
+
+import "fmt"
+
+func Extract(extension, src, dest string) error {
+	switch extension {
+	case "zip":
+		_, err := Unzip(src, dest)
+		return err
+	case "tgz":
+		return ExtractTarGz(src, dest)
+	default:
+		return fmt.Errorf("unknown file extension: %s", extension)
+	}
+}


### PR DESCRIPTION
This PR fixes the following lint errors:
* 36-156 lines are duplicate of `deps/bin.go:181-200`
* 69-102 lines are duplicate of `deps/lib.go:132-165`
* G305: File traversal when extracting zip/tar archive protecting from `ZipSlip`
* G110: Potential DoS vulnerability via decompression bomb
* importShadow: shadow of imported package 'filepath'