### PR TITLE
isolate GoBin type dependencies

### DIFF
--- a/deps/shared.go
+++ b/deps/shared.go
@@ -14,6 +14,7 @@ import (
 const (
 	externalDir = ".ext"
 	binDir      = "bin"
+	goBinDir    = "gobin"
 	libDir      = "lib"
 	tmpDir      = "tmp"
 )
@@ -120,8 +121,15 @@ func LibDir() string {
 	return filepath.Join(currentDir, externalDir, libDir)
 }
 
+// LibDir returns the absolute path to the ext tmp dir
 func ExtTmpDir() string {
 	return filepath.Join(currentDir, externalDir, tmpDir)
+}
+
+// GoBinDir returns the absolute path to the bin directory of tools
+// that are not go.
+func GoBinDir() string {
+	return filepath.Join(currentDir, externalDir, goBinDir)
 }
 
 func tmpFile(name string) string {


### PR DESCRIPTION
This PR:
* updates `deps.BinDir()`, `LibDir()`, `ExtTmpDir()` and `GoBinDir()` to correctly return the absolute path instead of the relative path
* makes Go Bin dependency type install in `.ext/gobin/{name}-{version}` similar to the Bin dependencies
* updates `GoDep` to use the dependency installed by Dep instead of the system provided binary.
* adds the `entrypoint` parameter to GoBin type dependency that allows overwriting the entrypoint for a Go dependency.