### PR TITLE
Gitleaks alibaba-access-key-id rule matches on word boundaries

### DIFF
--- a/common/gitleaks.go
+++ b/common/gitleaks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zricethezav/gitleaks/v8/git"
 )
 
-//nolint Gitleaks rules
+// nolint Gitleaks rules
 var GitleakConfig = []byte(`title = "gitleaks config"
 
 # Gitleaks rules are defined by regular expressions and entropy ranges.
@@ -192,7 +192,7 @@ regex = '''(p8e-)(?i)[a-z0-9]{32}'''
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Alibaba AccessKey ID"
-regex = '''(LTAI)(?i)[a-z0-9]{20}'''
+regex = '''\W(LTAI)(?i)[a-z0-9]{20}\W'''
 
 [[rules]]
 id = "alibaba-secret-key"


### PR DESCRIPTION
The rule, as it was written, matched substrings within longer strings.
This caused a false-positive match against a package hash in a go.sum file.

This PR tightens the rule to only match on word boundaries.

This _will_ alert on:
```go
var x = "LTAI563KZ5YKYRhT3MFKZMbjx"
```

But will not match:
```
github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
```